### PR TITLE
dynamically enable or disable connection to influx

### DIFF
--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -84,6 +84,9 @@
 
 # Configuration for influxdb server to send metrics to
 [[outputs.influxdb]]
+# Check if this has been enabled or disabled before continuing
+{% if influxdb_enabled is not defined or influxdb_enabled != "false" %}
+
   # The full HTTP or UDP endpoint URL for your InfluxDB instance.
   # Multiple urls can be specified but it is assumed that they are part of the same
   # cluster, this means that only ONE of the urls will be written to each interval.
@@ -132,6 +135,7 @@
   ## Use SSL but skip chain & host verification
 {% if telegraf_influxdb_insecure_skip_verify is defined and telegraf_influxdb_insecure_skip_verify != None %}
   # insecure_skip_verify = telegraf_influxdb_insecure_skip_verify
+{% endif %}
 {% endif %}
 
 ###############################################################################


### PR DESCRIPTION
we want the setup to remain the same (enable the connection) if no flag is present for compatibility reasons