### PR TITLE
Add procstat plugin

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,9 @@ telegraf_metrics_filtered: []
 telegraf_plugins_base:
   - name: mem
   - name: system
+  - name: procstat
+    options:
+      pattern: "%"
   - name: cpu
     options:
       percpu: "false"


### PR DESCRIPTION
Fixes https://github.com/ActionIQ/aiq/issues/11067

I (think) this spits out the equivalent telegraf:

```
[[inputs.procstat]]
    pattern = "%"
```

This gets us stuff like this:

https://gist.github.com/MasterDDT/8648f95bf95b873cb21e09526609ccc0

Those `java` are spark-workers or executors, hard to know which. But at least we can graph all process mem vs box mem and see whats happening.