### PR TITLE
Skip influx via conf

### DIFF
--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -85,11 +85,11 @@
   listen = "0.0.0.0:9273"
   namedrop = [ "{{ telegraf_metrics_filtered|join('", "') }}" ]
 
-# Configuration for influxdb server to send metrics to
-[[outputs.influxdb]]
 # Check if this has been enabled or disabled before continuing
 {% if influxdb_enabled is not defined or influxdb_enabled != "false" %}
 
+# Configuration for influxdb server to send metrics to
+[[outputs.influxdb]]
   # The full HTTP or UDP endpoint URL for your InfluxDB instance.
   # Multiple urls can be specified but it is assumed that they are part of the same
   # cluster, this means that only ONE of the urls will be written to each interval.
@@ -140,6 +140,7 @@
 {% if telegraf_influxdb_insecure_skip_verify is defined and telegraf_influxdb_insecure_skip_verify != None %}
   # insecure_skip_verify = telegraf_influxdb_insecure_skip_verify
 {% endif %}
+
 {% endif %}
 
 ###############################################################################


### PR DESCRIPTION
Related to https://github.com/ActionIQ/aiq/issues/11445

I see this in the logs, I assume it was trying to write to all the default places because the `[[outputs]]` was still there, but with no server/port:

```
2018-04-11T18:44:02Z E! Error writing to output [influxdb]: Could not write to any InfluxDB server in cluster
2018-04-11T18:45:00Z E! Error in plugin [inputs.influxdb]: [url=http://localhost:8086/debug/vars]: Get http://localhost:8086/debug/vars: dial tcp 127.0.0.1:8086: getsockopt: connection refused
```