### PR TITLE
Make config filename a variable

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -14,7 +14,7 @@
 - name: Set templatized Telegraf configuration
   template:
     src: telegraf.conf.j2
-    dest: "{{ telegraf_configuration_dir }}/telegraf.conf"
+    dest: "{{ telegraf_configuration_dir }}/{{ telegraf_configuration_filename }}"
     force: yes
     backup: yes
     owner: telegraf

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,3 +14,4 @@ telegraf_template_configuration: yes
 # Path for finding Telegraf data. Added for backwards-compatibility.
 telegraf_binary_path: /usr/bin/telegraf
 telegraf_configuration_dir: /etc/telegraf
+telegraf_configuration_filename: telegraf.conf


### PR DESCRIPTION
Since changing the config filename to something that doesn't end in `.conf` is much easier than putting it somewhere in `/tmp` then trying to move it